### PR TITLE
Allow customization of json serialization settings for messages

### DIFF
--- a/Blacksmith.Core/Client.cs
+++ b/Blacksmith.Core/Client.cs
@@ -108,7 +108,7 @@ namespace Blacksmith.Core
             }
             if (response.StatusCode == HttpStatusCode.OK) return json;
 
-            var error = JsonConvert.DeserializeObject<Error>(json);
+            var error = JsonConvert.DeserializeObject<Error>(json, ConfigurationWrapper.JsonSettings);
             throw new HttpException((int)response.StatusCode, error.Message);
         }
 

--- a/Blacksmith.Core/ConfigurationWrapper.cs
+++ b/Blacksmith.Core/ConfigurationWrapper.cs
@@ -1,9 +1,27 @@
 ﻿using System.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 
 namespace Blacksmith.Core
 {
     public class ConfigurationWrapper
     {
+        /// <summary>
+        /// Initializes the <see cref="ConfigurationWrapper"/> class.
+        /// </summary>
+        static ConfigurationWrapper()
+        {
+            // default configuration for the json serializer (for better non C# compatibility)
+            JsonSettings = new JsonSerializerSettings {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            };
+
+            JsonSettings.Converters.Add(new ExpandoObjectConverter());
+            JsonSettings.Converters.Add(new IsoDateTimeConverter());
+            JsonSettings.Converters.Add(new StringEnumConverter());
+        }
+
         public virtual string BlacksmithProjectId
         {
             get { return ConfigurationManager.AppSettings.GetValueOrDefault("blacksmith.projectId", ""); }
@@ -19,5 +37,13 @@ namespace Blacksmith.Core
         {
             get { return ConfigurationManager.AppSettings.GetValueOrDefault("blacksmith.optional.fixed.queuename", ""); }
         }
+
+        /// <summary>
+        /// Gets or sets the json settings.
+        /// </summary>
+        /// <value>
+        /// The json settings.
+        /// </value>
+        public static JsonSerializerSettings JsonSettings { get; set; }
     }
 }

--- a/Blacksmith.Core/Responses/Message.cs
+++ b/Blacksmith.Core/Responses/Message.cs
@@ -47,7 +47,7 @@ namespace Blacksmith.Core.Responses
         [JsonIgnore]
         public T Target
         {
-            get { return JsonConvert.DeserializeObject<T>(Body); }
+            get { return JsonConvert.DeserializeObject<T>(Body, ConfigurationWrapper.JsonSettings); }
         }
     }
 }

--- a/Blacksmith.Core/Responses/Subscriptions.cs
+++ b/Blacksmith.Core/Responses/Subscriptions.cs
@@ -31,9 +31,9 @@ namespace Blacksmith.Core.Responses
     }
 
     [Serializable]
-    public class Subcsription
+    public class Subscription
     {
-        public Subcsription()
+        public Subscription()
         {
             Subscribers = new Subscriber[0];
         }


### PR DESCRIPTION
I've done some changes to allow the customization of the JsonSettings for the serializer of user messages.

Now, clients can change the ConfigurationWrapper.JsonSettings to change how the message is serialized/deserialized, to make better compatibility with others languages (in my case, Java).

All tests passed!
