### PR TITLE
Added ability to enter queue names by a mapping in the ConfigurationWrap...

### DIFF
--- a/Blacksmith.Core/Blacksmith.Core.csproj
+++ b/Blacksmith.Core/Blacksmith.Core.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\BeeDrone\packages\Newtonsoft.Json.5.0.6\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/Blacksmith.Core/BlacksmithExtensionMethods.cs
+++ b/Blacksmith.Core/BlacksmithExtensionMethods.cs
@@ -51,15 +51,29 @@ namespace Blacksmith.Core
                 var attributes = type.GetCustomAttributes(typeof(QueueNameAttribute), false);
 
                 if (!attributes.Any())
-                    return type.FullName;
+                    return FindQueueNameMappingOrUseFullName(type);
 
                 var attribute = attributes.Cast<QueueNameAttribute>().First();
+
                 return attribute.Name;
             }
-            else
-            {
-                return config.OptionalFixedQueueName;
-            }
+
+            return config.OptionalFixedQueueName;
+        }
+
+        /// <summary>
+        /// Checks if the type has a mapped queue name to use; otherwise uses its full name.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns></returns>
+        private static string FindQueueNameMappingOrUseFullName(Type type)
+        {
+            string queueName;
+
+            if (!ConfigurationWrapper.QueueNameMappings.TryGetValue(type, out queueName))
+                queueName = type.FullName;
+
+            return queueName;
         }
     }
 

--- a/Blacksmith.Core/ConfigurationWrapper.cs
+++ b/Blacksmith.Core/ConfigurationWrapper.cs
@@ -1,4 +1,6 @@
-﻿using System.Configuration;
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
@@ -45,5 +47,13 @@ namespace Blacksmith.Core
         /// The json settings.
         /// </value>
         public static JsonSerializerSettings JsonSettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets the queue name mappings.
+        /// </summary>
+        /// <value>
+        /// The queue name mappings.
+        /// </value>
+        public static Dictionary<Type, string> QueueNameMappings { get; set; }
     }
 }

--- a/Blacksmith.Core/packages.config
+++ b/Blacksmith.Core/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Just another small feature. Sometimes the use of attributes, even when its only metadata is not desired for the application. So to maintain the compability between systems (Java and .NET again) I have to create a mapping to allow registering the queue names by configuration.

I, for some reason, updated the json.net version, but that is not really required.

The last changes was not updated in the NuGet :)
