### PR TITLE
Specifying queue name in code

### DIFF
--- a/Blacksmith.Core/Blacksmith.Core.csproj
+++ b/Blacksmith.Core/Blacksmith.Core.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.5.0.6\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/Blacksmith.Core/Client.cs
+++ b/Blacksmith.Core/Client.cs
@@ -82,6 +82,19 @@ namespace Blacksmith.Core
             return new QueueWrapper<TMessage>(this);
         }
 
+        /// <summary>
+        /// Queues are based on message types, where TMessage is your class. Your class can contain anything that is serializable.
+        /// </summary>
+        /// <typeparam name="TMessage">your message</typeparam>
+        /// <param name="queueName">Name of queue if different from message typename</param>
+        /// <returns>a fluent interface to let you construct a request.</returns>
+        public QueueWrapper<TMessage> Queue<TMessage>(string queueName)
+            where TMessage : class
+        {
+            return new QueueWrapper<TMessage>(this, queueName);
+        }
+
+
         private string Request(string method, string endpoint, string body)
         {
             string path = string.Format("/{0}/projects/{1}/{2}", ApiVersion, _projectId, endpoint);

--- a/Blacksmith.Core/QueueWrapper.cs
+++ b/Blacksmith.Core/QueueWrapper.cs
@@ -20,11 +20,14 @@ namespace Blacksmith.Core
                 DefaultValueHandling = DefaultValueHandling.Ignore
             };
 
-            public QueueWrapper(Client client)
+            
+            public QueueWrapper(Client client) : this(client, typeof(TMessage).GetQueueName()) {}
+            public QueueWrapper(Client client, string queueName)
             {
                 _client = client;
-                Name = typeof(TMessage).GetQueueName();
-            }
+                Name = queueName;
+            } 
+
 
             protected string Name { get; set; }
 

--- a/Blacksmith.Core/packages.config
+++ b/Blacksmith.Core/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net40" />
 </packages>

--- a/Blacksmith.Tests/Blacksmith.Tests.csproj
+++ b/Blacksmith.Tests/Blacksmith.Tests.csproj
@@ -44,8 +44,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit">
-      <HintPath>..\packages\xunit.1.9.1\lib\net20\xunit.dll</HintPath>
+    <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Blacksmith.Tests/packages.config
+++ b/Blacksmith.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="2.0.1" targetFramework="net40" />
-  <package id="xunit" version="1.9.1" targetFramework="net45" />
+  <package id="xunit" version="1.9.2" targetFramework="net40" />
 </packages>

--- a/Blacksmith.jmconfig
+++ b/Blacksmith.jmconfig
@@ -1,0 +1,1 @@
+﻿<?xml version="1.0" encoding="utf-8"?><Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><DontShowAgainInSolution>false</DontShowAgainInSolution></Configuration>


### PR DESCRIPTION
I´d like to suggest to include passing the queue name in code to override the default (typename of message). Example:

```
client.Queue<NewsItem>("GreatNews").Next().Consume(...);
```

Hope you like this.

-Ralf
