### PR TITLE
Made name of queue public on QueueWrapper

### DIFF
--- a/Blacksmith.Core/Blacksmith.Core.csproj
+++ b/Blacksmith.Core/Blacksmith.Core.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Blacksmith.Core.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Blacksmith.Core/QueueWrapper.cs
+++ b/Blacksmith.Core/QueueWrapper.cs
@@ -29,7 +29,11 @@ namespace Blacksmith.Core
             } 
 
 
-            protected string Name { get; set; }
+            /// <summary>
+            /// Name of queue in iron.io project
+            /// </summary>
+            public string Name { get; protected set; }
+
 
             /// <summary>
             /// Use this method to handle scenarios where the queue is perceived to be empty. There may still be some defered messages in the queue or messages waiting to timeout.

--- a/Blacksmith.Sample/Program.cs
+++ b/Blacksmith.Sample/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Timers;
 using Blacksmith.Core;
+using Blacksmith.Core.Attributes;
 
 namespace Blacksmith.Sample
 {
@@ -70,6 +71,7 @@ namespace Blacksmith.Sample
         }
     }
 
+    // [QueueName("QueueForMyMessage")] // Use to override automatic queue name generation from typename
     public class MyMessage
     {
         public string Text { get; set; }


### PR DESCRIPTION
With the name of the queue public on the QueueWrapper code can "reflect" on queues held in a list.
Also I did not understand why the Name property had been protected in the first place ;-)
But to honor any reason I did not understand I just made the getter public and left the setter protected.

Also I introduced [QueueName(...)] to the sample - as a comment - to show this capability.
