### PR TITLE
Allow header settings on subscriber urls

### DIFF
--- a/Blacksmith.Core/Blacksmith.Core.csproj
+++ b/Blacksmith.Core/Blacksmith.Core.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.5\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/Blacksmith.Core/IQueueWrapper.cs
+++ b/Blacksmith.Core/IQueueWrapper.cs
@@ -40,7 +40,7 @@ namespace Blacksmith.Core
         /// <param name="subscriberUrls"></param>
         /// <returns></returns>
         QueueSettings Update(int retries = 3, int retriesDelay = 60, string pushType = "multicast", string errorQueue = null,
-            string[] subscriberUrls = null);
+            Subscriber[] subscribers = null);
 
         /// <summary>
         /// Peeking at a queue returns the next messages on the queue, but it does not reserve them. Don't use this for processing messages, use Next or Get.
@@ -127,7 +127,7 @@ namespace Blacksmith.Core
         /// </summary>
         /// <param name="urls"></param>
         /// <returns></returns>
-        Subscription Subscribe(params string[] urls);
+        Subscription Subscribe(params Subscriber[] subscribers);
 
         /// <summary>
         /// Removes subscribers (HTTP endpoints) to a queue. This is for Push Queues only.

--- a/Blacksmith.Core/QueueWrapper.cs
+++ b/Blacksmith.Core/QueueWrapper.cs
@@ -76,14 +76,14 @@ namespace Blacksmith.Core
             /// <param name="subscriberUrls"></param>
             /// <returns></returns>
             public virtual QueueSettings Update(int retries = 3, int retriesDelay = 60, string pushType = "multicast", string errorQueue = null,
-                                              string[] subscriberUrls = null)
+                                              Subscriber[] subscribers = null)
             {
                 var request = new QueueUpdate {
                     PushType = pushType,
                     Retries = retries,
                     RetriesDelay = retriesDelay,
                     ErrorQueue = errorQueue,
-                    Subscribers = (subscriberUrls ?? new string[0]).Select(x => new Subscriber(x)).ToArray()
+                    Subscribers = (subscribers ?? new Subscriber[0]).Select(x => new Subscriber(x.Url, x.Headers)).ToArray()
                 };
 
                 var body = JsonConvert.SerializeObject(request, ConfigurationWrapper.JsonSettings);
@@ -246,11 +246,11 @@ namespace Blacksmith.Core
             /// </summary>
             /// <param name="urls"></param>
             /// <returns></returns>
-            public virtual Subscription Subscribe(params string[] urls)
+            public virtual Subscription Subscribe(Subscriber[] subscribers)
             {
-                if (urls == null || !urls.Any())
-                    throw new ArgumentException("at least one url is required", "urls");
-                var request = new Subscriptions { Subscribers = urls.Select(x => new Subscriber { Url = x }).ToArray() };
+                if (subscribers == null || !subscribers.Any())
+                    throw new ArgumentException("at least one subscriber is required", "urls");
+                var request = new Subscriptions { Subscribers = subscribers.Select(x => new Subscriber { Url = x.Url, Headers = x.Headers }).ToArray() };
 
                 var json = JsonConvert.SerializeObject(request);
                 var response = _client.Post(string.Format("queues/{0}/subscribers", Name), json);

--- a/Blacksmith.Core/Responses/Subscriptions.cs
+++ b/Blacksmith.Core/Responses/Subscriptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Blacksmith.Core.Responses
 {
@@ -26,8 +27,17 @@ namespace Blacksmith.Core.Responses
             Url = url;
         }
 
+        public Subscriber(string url, Dictionary<string, string> headers)
+        {
+            Url = url;
+            Headers = headers;
+        }
+
         [JsonProperty("url")]
         public string Url { get; set; }
+
+        [JsonProperty("headers")]
+        public dynamic Headers { get; set; }
     }
 
     [Serializable]

--- a/Blacksmith.Core/packages.config
+++ b/Blacksmith.Core/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net40" />
 </packages>

--- a/Blacksmith.Tests/ClientTests.cs
+++ b/Blacksmith.Tests/ClientTests.cs
@@ -7,6 +7,7 @@ using Blacksmith.Core.Attributes;
 using FluentAssertions;
 using Xunit;
 using Blacksmith.Core.Responses;
+using System.Collections.Generic;
 
 namespace Blacksmith.Tests
 {
@@ -202,8 +203,8 @@ namespace Blacksmith.Tests
                     }";
                 };
 
-
-            var subscriptions = Client.Queue<Stub>().Subscribe(new Subscriber("http://localhost"));
+            var headers = new Dictionary<string, string>() { { "Content-Type", "application/json" } };
+            var subscriptions = Client.Queue<Stub>().Subscribe(new Subscriber("http://localhost", headers));
             endpoint.Should().Be("queues/Blacksmith.Tests.ClientTests+Stub/subscribers");
             subscriptions.Should().NotBeNull();
             subscriptions.TotalMessages.Should().Be(7);

--- a/Blacksmith.Tests/ClientTests.cs
+++ b/Blacksmith.Tests/ClientTests.cs
@@ -6,6 +6,7 @@ using Blacksmith.Core;
 using Blacksmith.Core.Attributes;
 using FluentAssertions;
 using Xunit;
+using Blacksmith.Core.Responses;
 
 namespace Blacksmith.Tests
 {
@@ -202,7 +203,7 @@ namespace Blacksmith.Tests
                 };
 
 
-            var subscriptions = Client.Queue<Stub>().Subscribe("http://localhost");
+            var subscriptions = Client.Queue<Stub>().Subscribe(new Subscriber("http://localhost"));
             endpoint.Should().Be("queues/Blacksmith.Tests.ClientTests+Stub/subscribers");
             subscriptions.Should().NotBeNull();
             subscriptions.TotalMessages.Should().Be(7);


### PR DESCRIPTION
Changed queue to take a subscriber that may have a header dictionary. This allows for iron mq header settings to be applied.

Currently these are breaking changes. I am happy to refactor to allow backwards compatibility based on your recommendations. Let me know.
